### PR TITLE
Add conductor.json and bin scripts for Conductor workspace support

### DIFF
--- a/bin/conductor-run
+++ b/bin/conductor-run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PORT="${CONDUCTOR_PORT:-3000}" BROWSER=none GENERATE_SOURCEMAP=false npm start

--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+npm install

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "bin/conductor-setup",
+        "run": "bin/conductor-run"
+    }
+}


### PR DESCRIPTION
## Summary
- Add repo-root `conductor.json` declaring shared `setup`/`run` scripts per the Conductor spec
- Add `bin/conductor-setup` (`npm install`) and `bin/conductor-run` (CRA dev server on `$CONDUCTOR_PORT`, `BROWSER=none`, `GENERATE_SOURCEMAP=false` to silence intro.js vendor source-map warnings)

## Test plan
- [ ] Create a fresh Conductor workspace from this branch and confirm the setup script runs automatically
- [ ] Click Run and confirm the dev server starts on the assigned workspace port with no browser auto-opening and no source-map warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)